### PR TITLE
chore: re-work notifications types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
I've tried to stay away from types that we couldn't immediately use (e.g. service upgrade available but user-initiated upgrade needs to be undertaken). Those can be added as we work on adding the corresponding functionality to take advantage of them.