### PR TITLE
chore: add ProjectRestoredFromBackup to ProjectEvents enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,7 +4,8 @@ import { ServiceNames } from './constants'
 export enum ProjectEvents {
   ProjectPaused = 'project.paused',
   ProjectRestored = 'project.restored',
-  ProjectRestoredFromBackup = 'project.restored_from_backup',
+  ProjectRestoredFromLogicalBackup = 'project.restored_from_logical_backup',
+  ProjectRestoredFromPitr = 'project.restored_from_pitr',
   ProjectPendingShutdown = 'project.pending_shutdown_notification',
   ProjectShutdownEligible = 'project.shutdown_eligible',
   ProjectJwtSecretUpdateStatusChange = 'project.jwt_secret_update_status_change',

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,6 +4,7 @@ import { ServiceNames } from './constants'
 export enum ProjectEvents {
   ProjectPaused = 'project.paused',
   ProjectRestored = 'project.restored',
+  ProjectRestoredFromBackup = 'project.restored_from_backup',
   ProjectPendingShutdown = 'project.pending_shutdown_notification',
   ProjectShutdownEligible = 'project.shutdown_eligible',
   ProjectJwtSecretUpdateStatusChange = 'project.jwt_secret_update_status_change',


### PR DESCRIPTION
This PR introduces two new events for the `ProjectEvents` enum: 
* `ProjectRestoredFromLogicalBackup` to log an event upon a successful restoration with the use of logical backups.
* `ProjectRestoredFromPitr` to log an event upon a successful restoration with the use of point in time recovery.