### PR TITLE
chore: add kps_enabled to ProjectInitializationBasePayload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -28,6 +28,7 @@ export interface ProjectInitializationBasePayload {
   anon_key_encrypted: string
   api_id: string
   initialization_type: InitializationType
+  kps_enabled: boolean
   payload_version: InitializationPayloadVersion
   project_id: number
   service_key_encrypted: string


### PR DESCRIPTION
Will be primarily used for the transition to new and unpaused projects running without KPS.