### PR TITLE
chore: add action reason enum and changelog link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -29,9 +29,15 @@ export enum ActionType {
   PgBouncerRestart = 'pgbouncer.restart',
 }
 
+export enum ActionReason {
+  Apply = 'apply',
+  Rollback = 'rollback',
+  Finalize = 'finalize',
+}
+
 export interface Action {
   action_type: ActionType
-  reason?: string
+  reason?: string | ActionReason
   deadline?: Date
 }
 
@@ -93,6 +99,7 @@ export type PostgresqlUpgradeData = {
   name: NotificationName.PostgresqlUpgradeAvailable | NotificationName.PostgresqlUpgradeCompleted
   upgrade_type: 'postgresql-server' | 'extensions' | 'schema-migration'
   additional: ServerUpgrade | ExtensionsUpgrade
+  changelog_link?: string
 }
 
 // ProjectUpdateCompleted


### PR DESCRIPTION
## What kind of change does this PR introduce?

more action types for FE

## What is the current behavior?

reason field is abused with changelog link

## What is the new behavior?

- adds `ActionReason` enum to further distinguish action types
- adds `changelog_link` to clarify postgres upgrade notifications

## Additional context

Add any other context or screenshots.
