### PR TITLE
Bump version number for new npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -125,5 +125,5 @@ export type LinkedButton = {
 export type ProjectInformationalData = {
   name: NotificationName.ProjectInformational
   message: string
-  linked_buttons: LinkedButton[]
+  linked_buttons?: LinkedButton[]
 }

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -117,7 +117,13 @@ export type ProjectUpdateData = {
 
 // informational
 
+export type LinkedButton = {
+  text: string
+  url: string
+}
+
 export type ProjectInformationalData = {
   name: NotificationName.ProjectInformational
   message: string
+  linked_buttons: LinkedButton[]
 }


### PR DESCRIPTION
Need to release the following changes to the shared types as a new npm release:
https://github.com/supabase/shared-types/pull/40

The changes are needed for adding linked buttons on studio notifications
https://github.com/supabase/supabase/pull/14639