### PR TITLE
chore: init new ProjectEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/events.ts
+++ b/src/events.ts
@@ -13,8 +13,10 @@ export enum ProjectEvents {
   ProjectServiceConfigUpdate = 'project.service_config_update',
   ProjectSansKpsMigrationInitiated = 'project.sans_kps_migration_initiated',
   ProjectSansKpsMigrationCompleted = 'project.sans_kps_migration_completed',
+  ProjectConfigUpdated = 'project.config_updated',
   ProjectDatabaseUpgradeStatusChange = 'project.database_upgrade_status_change',
   ProjectInfrastructureUpdated = 'project.infra_updated',
+  ProjectInfrastructureRestarted = 'project.infra_restarted',
   PostgresqlRestart = 'postgresql.restart',
   ProjectWalgUpdated = 'project.walg_updated',
   ProjectSubscriptionUpdated = 'project.subscription_updated',
@@ -104,6 +106,7 @@ export interface UpdateConfigPayload {
   project_id: number
   service_names: ServiceNames[]
   restart_services: boolean
+  database_id?: number
 }
 
 export interface DismissNotificationsPayload {


### PR DESCRIPTION
* To support changes to updating configs
    * `ProjectConfigUpdated` for events whenever config changes are made to specific database instances
    * Update `UpdateConfigPayload` to take in an optional `database_id` field
* To support logging instance restarts
    * Through introducing `ProjectInfrastructureRestarted`