### PR TITLE
chore: add desired instance size param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.47",
+  "version": "0.1.59",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@supabase/shared-types",
-      "version": "0.1.47",
+      "version": "0.1.59",
       "license": "Copyright Supabase",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -25,6 +25,20 @@ export enum InitializationType {
   Restore = 'restore',
 }
 
+export enum ProjectDbInstanceSize {
+  NANO = 'nano',
+  MICRO = 'micro',
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
+  XLARGE = 'xlarge',
+  XLARGE_2 = '2xlarge',
+  XLARGE_4 = '4xlarge',
+  XLARGE_8 = '8xlarge',
+  XLARGE_12 = '12xlarge',
+  XLARGE_16 = '16xlarge',
+}
+
 export interface ProjectInitializationBasePayload {
   anon_key_encrypted: string
   api_id: string
@@ -33,6 +47,7 @@ export interface ProjectInitializationBasePayload {
   project_id: number
   service_key_encrypted: string
   database_id: number
+  desired_instance_size?: ProjectDbInstanceSize
 }
 
 export interface NewProjectInitializationPayload extends ProjectInitializationBasePayload {


### PR DESCRIPTION
With the move to nano, we'd like to control instance sizes when initializing projects. This could also be neither nano nor micro, but an even higher compute.