### PR TITLE
chore: move types to shared folder in infra

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@supabase/shared-types",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "license": "Copyright Supabase",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -15,50 +15,6 @@ export interface UpdateSupabaseApiKeyPayload {
   next_api_key_supabase_encrypted: string
 }
 
-export enum InitializationPayloadVersion {
-  Version1 = 1,
-  Version2 = 2,
-}
-
-export enum InitializationType {
-  NewProject = 'new_project',
-  Restore = 'restore',
-}
-
-export enum ProjectDbInstanceSize {
-  NANO = 'nano',
-  MICRO = 'micro',
-  SMALL = 'small',
-  MEDIUM = 'medium',
-  LARGE = 'large',
-  XLARGE = 'xlarge',
-  XLARGE_2 = '2xlarge',
-  XLARGE_4 = '4xlarge',
-  XLARGE_8 = '8xlarge',
-  XLARGE_12 = '12xlarge',
-  XLARGE_16 = '16xlarge',
-}
-
-export interface ProjectInitializationBasePayload {
-  anon_key_encrypted: string
-  api_id: string
-  initialization_type: InitializationType
-  payload_version: InitializationPayloadVersion
-  project_id: number
-  service_key_encrypted: string
-  database_id: number
-  desired_instance_size?: ProjectDbInstanceSize
-}
-
-export interface NewProjectInitializationPayload extends ProjectInitializationBasePayload {
-  auth_site_url: string
-  db_sql: string
-}
-
-export interface RestoreProjectPayload extends ProjectInitializationBasePayload {
-  backup_id: number
-}
-
 export enum BackupSchedulePayloadType {
   Create = 'create',
   Update = 'update',


### PR DESCRIPTION
We don't need to publicly expose the worker job format or our ProjectDbInstanceSizes. Dashboard is using neither.

Moved to `shared` folder in supabase/infrastructure.