### PR TITLE
chore: add granular events for read replica setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/events.ts
+++ b/src/events.ts
@@ -102,6 +102,30 @@ export enum DatabaseUpgradeError {
   UpgradeCompletionFailed = '8_upgrade_completion_failed',
 }
 
+export enum ReadReplicaSetupStatus {
+  SettingUp,
+  Completed,
+  Failed,
+}
+
+export enum ReadReplicaSetupProgress {
+  Requested = '0_requested',
+  Started = '1_started',
+  LaunchedReadReplicaInstance = '2_launched_read_replica_instance',
+  InitiatedReadReplicaSetup = '3_initiated_read_replica_setup',
+  DownloadedBaseBackup = '4_downloaded_base_backup',
+  ReplayedWalArchives = '5_replayed_wal_archives',
+  CompletedReadReplicaSetup = '6_completed_read_replica_setup',
+}
+
+export enum DatabaseUpgradeError {
+  ReadReplicaInstanceLaunchFailed = '1_read_replica_instance_launch_failed',
+  InitiateReadReplicaSetupFailed = '2_initiate_read_replica_setup_failed',
+  DownloadBaseBackupFailed = '3_download_base_backup_failed',
+  ReplayWalArchivesFailed = '4_replay_wal_archives_failed',
+  CompleteReadReplicaSetupFailed = '5_complete_read_replica_setup_failed',
+}
+
 export interface RestartServicePayload {
   project_id: number
   service_names: ServiceNames[]

--- a/src/events.ts
+++ b/src/events.ts
@@ -29,6 +29,7 @@ export enum ProjectEvents {
   ProjectIPv4AddressUpdate = 'project.network.ipv4_update',
   ProjectAddonUpdated = 'project.addon_updated',
   ProjectServiceLifecycleChange = 'project.service_lifecycle_change',
+  ProjectReadReplicaSetupStatusChange = 'project.read_replica_setup_status_change',
 }
 
 export enum ProjectDiskGrowth {
@@ -118,7 +119,7 @@ export enum ReadReplicaSetupProgress {
   CompletedReadReplicaSetup = '6_completed_read_replica_setup',
 }
 
-export enum DatabaseUpgradeError {
+export enum ReadReplicaSetupError {
   ReadReplicaInstanceLaunchFailed = '1_read_replica_instance_launch_failed',
   InitiateReadReplicaSetupFailed = '2_initiate_read_replica_setup_failed',
   DownloadBaseBackupFailed = '3_download_base_backup_failed',


### PR DESCRIPTION
* Main objective would be able to provide more granular updates on read replica initialization on the dashboard