### PR TITLE
fix: move wpp event to its own enum for easier later expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@supabase/shared-types",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "license": "Copyright Supabase",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/events.ts
+++ b/src/events.ts
@@ -25,7 +25,6 @@ export enum ProjectEvents {
   ProjectDiskGrowth = 'project.disk_growth',
   ProjectSoftwareUpgraded = 'project.software_upgraded',
   ProjectTransfered = 'project.transfered',
-  ProjectTransferredFromWarmPool = 'project.transfered_from_warm_pool',
   ProjectPhysicalBackupTransition = 'project.physical_backup_transition',
   ProjectPhysicalBackupIneligible = 'project.physical_backup_ineligible',
   ProjectIPv4AddressUpdate = 'project.network.ipv4_update',
@@ -36,6 +35,10 @@ export enum ProjectEvents {
   ProjectRestoreFailed = 'project.restore_failed',
   ProjectRestoreCancelled = 'project.restore_cancelled',
   ProjectStorageArchiveCompleted = 'project.storage_archive_completed',
+}
+
+export enum WarmProjectPoolEvents {
+  Transferred = 'transfered_from_warm_project_pool',
 }
 
 export enum ProjectCloningEvents {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Move the new WPP event type to it's own event type so that it can be easily expanded over time. The ProjectEvent type is tied to views and is not much fun to mess with.