### PR TITLE
fix: revert move wpp event to its own enum for easier later expansion (#92)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.79",
+  "version": "0.1.78",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@supabase/shared-types",
-      "version": "0.1.79",
+      "version": "0.1.78",
       "license": "Copyright Supabase",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.79",
+  "version": "0.1.78",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/events.ts
+++ b/src/events.ts
@@ -25,6 +25,7 @@ export enum ProjectEvents {
   ProjectDiskGrowth = 'project.disk_growth',
   ProjectSoftwareUpgraded = 'project.software_upgraded',
   ProjectTransfered = 'project.transfered',
+  ProjectTransferredFromWarmPool = 'project.transfered_from_warm_pool',
   ProjectPhysicalBackupTransition = 'project.physical_backup_transition',
   ProjectPhysicalBackupIneligible = 'project.physical_backup_ineligible',
   ProjectIPv4AddressUpdate = 'project.network.ipv4_update',
@@ -35,10 +36,6 @@ export enum ProjectEvents {
   ProjectRestoreFailed = 'project.restore_failed',
   ProjectRestoreCancelled = 'project.restore_cancelled',
   ProjectStorageArchiveCompleted = 'project.storage_archive_completed',
-}
-
-export enum WarmProjectPoolEvents {
-  Transferred = 'transfered_from_warm_project_pool',
 }
 
 export enum ProjectCloningEvents {


### PR DESCRIPTION
This reverts commit b7fa4abe1b946694f4cf7c9b1e737204faa52fef.
