### PR TITLE
chore: add new types for project cloning events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/events.ts
+++ b/src/events.ts
@@ -37,6 +37,8 @@ export enum ProjectEvents {
   ProjectRestoreFailed = 'project.restore_failed',
   ProjectRestoreCancelled = 'project.restore_cancelled',
   ProjectStorageArchiveCompleted = 'project.storage_archive_completed',
+  ProjectClonedToTarget = 'project.cloned_to_target',
+  ProjectClonedFromSource = 'project.cloned_from_source',
 }
 
 export enum ProjectCloningEvents {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds two new project event types to be used with _Restore to a New Project_ operations. These will make it easier to track the source and target projects.