### PR TITLE
chore: use trusted publisher for release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
       # if the version hasn't changed, don't bother
       - package.json
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-24.04
@@ -15,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:
@@ -24,7 +28,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@supabase'
 
+      # Ensure npm 11.5.1 or later is installed for trusted publishing support
+      - name: Update npm
+        run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore, publishing should be done using trusted publisher and provenance.


## Additional context

[Add any other context or screenshots.](https://docs.npmjs.com/trusted-publishers)
