### PR TITLE
chore: Add new OAuth scope for analytics config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@supabase/shared-types",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "license": "Copyright Supabase",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,6 +61,8 @@ export enum PermissionAction {
 export enum OAuthScope {
   ANALYTICS_READ = 'analytics:read',
   ANALYTICS_WRITE = 'analytics:write',
+  ANALYTICS_CONFIG_READ = 'analytics_config:read',
+  ANALYTICS_CONFIG_WRITE = 'analytics_config:write',
   AUTH_READ = 'auth:read',
   AUTH_WRITE = 'auth:write',
   DATABASE_READ = 'database:read',


### PR DESCRIPTION
Introducing a new OAuth scope for these actions, because they are paid Team features and we want the OAuth consent to reflect this.