### PR TITLE
chore: version 0.1.88

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@supabase/shared-types",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "license": "Copyright Supabase",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/shared-types",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "description": "Shared Types for Supabase",
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
Version 0.1.87 failed to publish because of an npm regression, and my attempt to workaround the regression wasn't published due to path filtering, so trying again with a new version number.