### PR TITLE
chore: prepare CODEOWNERS for group renaming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @supabase/backend @supabase/api @supabase/billing
+* @supabase/backend @supabase/api @supabase/platform-control-plane @supabase/billing


### PR DESCRIPTION
This PR updates CODEOWNERS to prepare for renaming infrastructure teams:

- supabase/infra → supabase/platform
- supabase/infra-compute → supabase/platform-compute
- supabase/infra-data → supabase/platform-data
- supabase/infra-edge → supabase/platform-networking
- supabase/infra-ops → supabase/platform-ops
- supabase/infra-break-glass → supabase/platform-break-glass
- supabase/api → supabase/platform-control-plane
- supabase/infra-platform-services → (removed)

The new group names are added alongside the old ones. Once the GitHub teams are renamed, a follow-up PR will remove the old group references at the bottom of the file.
